### PR TITLE
Fix SELinux prop spoofing

### DIFF
--- a/module/service.sh
+++ b/module/service.sh
@@ -23,9 +23,7 @@ resetprop_if_match vendor.boot.mode recovery unknown
 
 # Hiding SELinux | Permissive status
 resetprop_if_diff ro.boot.selinux enforcing
-if [ -n "$(resetprop ro.build.selinux)" ]; then
-    resetprop --delete ro.build.selinux
-fi
+resetprop_if_diff ro.build.selinux 1
 
 # Hiding SELinux | Use toybox to protect *stat* access time reading
 if [[ "$(toybox cat /sys/fs/selinux/enforce)" == "0" ]]; then


### PR DESCRIPTION
Using `resetprop --delete` will trigger ro property manipulation detection.