### PR TITLE
Check if Shamiko whitelist is not active before configuring DenyList

### DIFF
--- a/module/post-fs-data.sh
+++ b/module/post-fs-data.sh
@@ -6,7 +6,9 @@ if magisk --denylist status; then
     magisk --denylist rm com.google.android.gms
 else
     # If DenyList is disabled, maybe you are using Shamiko
-    magisk --denylist add com.google.android.gms com.google.android.gms.unstable
+    if [ ! -f "/data/adb/shamiko/whitelist" ]; then
+        magisk --denylist add com.google.android.gms com.google.android.gms.unstable
+    fi
 fi
 
 # Uninstall conflict apps


### PR DESCRIPTION
Since creating a file named `whitelist` on `/data/adb/shamiko/` seems to be the only way to enable whitelist mode on Shamiko, and a lot of people are complaining about this.

This PR adds a single if statement to check that whitelist mode is not enabled, before adding` com.google.android.gms` and `com.google.android.gms.unstable` to DenyList.