### PR TITLE
Remove Selinux Prop spoofing

### DIFF
--- a/module/service.sh
+++ b/module/service.sh
@@ -10,10 +10,6 @@ resetprop_if_match vendor.boot.mode recovery unknown
 
 # SELinux
 resetprop_if_diff ro.boot.selinux enforcing
-# use delete since it can be 0 or 1 for enforcing depending on OEM
-if [ -n "$(resetprop ro.build.selinux)" ]; then
-    resetprop --delete ro.build.selinux
-fi
 # use toybox to protect stat access time reading
 if [ "$(toybox cat /sys/fs/selinux/enforce)" = "0" ]; then
     chmod 640 /sys/fs/selinux/enforce


### PR DESCRIPTION
I'd suggest either removing this line of code or have it set the property to 1 (which shouldn't be problematic as it's present on some stock ROMs) so it doesn't alarm detection systems and doesn't cause property deletion detection